### PR TITLE
fix: pyproject warnings when packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = []
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = "MIT"
 readme = "README.md"
 
 [project.optional-dependencies]
@@ -22,6 +22,9 @@ pyside6 = ["PySide6"]
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = false
 
 [tool.setuptools.packages.find]
 include = ["qt_themes"]


### PR DESCRIPTION
When I package `qt-themes` with setuptools, I noticed 2 warnings,
*SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated* and
*_Warning: Package 'qt_themes.themes' is absent from the `packages` configuration.* .

For the first warning, now python accepts only `"MIT"` to declare the license, stated [here].
For the seccond warning, python searchs directories, but the `themes` dir only contains some json files, so we should exclude it explicitly.

[here]: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license