### PR TITLE
feat: set theme for single widget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ description = "A collection of themes for Qt applications in Python."
 authors = [
     {name = "Beat Reichenbach"}
 ]
-dependencies = []
+dependencies = [
+    'qtpy',
+]
 requires-python = ">=3.9"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ description = "A collection of themes for Qt applications in Python."
 authors = [
     {name = "Beat Reichenbach"}
 ]
-dependencies = [
-    'qtpy',
-]
+dependencies = []
 requires-python = ">=3.9"
 license = "MIT"
 readme = "README.md"

--- a/qt_themes/__init__.py
+++ b/qt_themes/__init__.py
@@ -1,3 +1,11 @@
-from ._theme import Theme, get_theme, get_themes, set_theme, update_palette, set_widget_theme
+from ._theme import (
+    Theme,
+    get_theme,
+    get_themes,
+    set_theme,
+    set_widget_theme,
+    update_palette,
+)
+
 
 __version__ = '0.3.0'

--- a/qt_themes/__init__.py
+++ b/qt_themes/__init__.py
@@ -1,3 +1,3 @@
-from ._theme import Theme, get_theme, get_themes, set_theme, update_palette
+from ._theme import Theme, get_theme, get_themes, set_theme, update_palette, set_widget_theme
 
 __version__ = '0.3.0'

--- a/qt_themes/_theme.py
+++ b/qt_themes/_theme.py
@@ -110,7 +110,7 @@ def get_themes() -> dict[str, Theme]:
 
 
 def update_palette(palette: QtGui.QPalette, theme: Theme) -> None:
-    """Set the Theme for the given QPalette."""
+    """Set the theme for the given QPalette."""
 
     # Colors
     highlighted_color = theme.primary
@@ -181,8 +181,8 @@ def update_palette(palette: QtGui.QPalette, theme: Theme) -> None:
 
 def set_theme(theme: Theme | str | None, style: str | None = 'fusion') -> None:
     """
-    Sets the theme and style for the current QApplication.
-    By default, set the Fusion style as it works the best with QPalette ColorRoles.
+    Set the theme and style for the current QApplication.
+    By default, set the fusion style as it works the best with QPalette ColorRoles.
     """
 
     # Set style
@@ -207,12 +207,12 @@ def set_theme(theme: Theme | str | None, style: str | None = 'fusion') -> None:
         application.setProperty(PROPERTY_NAME, theme)
 
 
-def set_widget_theme(widget: QtWidgets.QWidget,
-                     theme: Theme | str | None,
-                     style: str | None = 'fusion') -> None:
+def set_widget_theme(
+    widget: QtWidgets.QWidget, theme: Theme | str | None, style: str | None = 'fusion'
+) -> None:
     """
-    Sets the theme and style for the given QWidget.
-    By default, set the Fusion style as it works the best with QPalette ColorRoles.
+    Set the theme and style for the given QWidget.
+    By default, set the fusion style as it works the best with QPalette ColorRoles.
     """
 
     # Set style
@@ -252,7 +252,7 @@ def _load(path: str) -> Theme:
 
 
 def _get_paths() -> tuple[str, ...]:
-    """Returns all paths to search for themes."""
+    """Return all paths to search for themes."""
 
     paths = [str(importlib.resources.files(qt_themes).joinpath('themes'))]
     if env_path := os.getenv(THEMES):

--- a/qt_themes/_theme.py
+++ b/qt_themes/_theme.py
@@ -207,6 +207,35 @@ def set_theme(theme: Theme | str | None, style: str | None = 'fusion') -> None:
         application.setProperty(PROPERTY_NAME, theme)
 
 
+def set_widget_theme(widget: QtWidgets.QWidget,
+                     theme: Theme | str | None,
+                     style: str | None = 'fusion') -> None:
+    """
+    Sets the theme and style for the given QWidget.
+    By default, set the Fusion style as it works the best with QPalette ColorRoles.
+    """
+
+    # Set style
+    if style:
+        widget.setStyle(QtWidgets.QStyleFactory.create(style))
+
+    # Reset theme
+    if not theme:
+        widget.setPalette(QtGui.QPalette())
+        return
+
+    # Set theme
+    if isinstance(theme, str):
+        theme = get_theme(theme)
+        if not theme:
+            return
+
+    palette = QtGui.QPalette()
+    update_palette(palette, theme)
+    widget.setPalette(palette)
+    widget.setProperty(PROPERTY_NAME, theme)
+
+
 def _load(path: str) -> Theme:
     """
     Return the theme from `path`.


### PR DESCRIPTION
Hi
I started to use your package for pymodaq theming and would like to propose these modifications to use qtpy

I also added a method to set the theme/style of individual widgets!

That gives that on pymodaq for the moment:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/0e55c3a2-ce51-4fa7-b021-1f7a9239a14c" />
